### PR TITLE
Added more draw options that can be called from Lua

### DIFF
--- a/TAMods/Config.cpp
+++ b/TAMods/Config.cpp
@@ -2333,6 +2333,7 @@ void Lua::init()
 
         // Custom HUD drawing functions
         addFunction("drawText",                &Utils::drawText).
+        addFunction("drawCustomText", &Utils::drawCustomText).
         addFunction("drawSmallText",        &Utils::drawSmallText).
         addFunction("drawUTText",            &Utils::drawUTText).
         addFunction("drawUTTextScaled",        &Utils::drawUTTextScaled).
@@ -2344,6 +2345,12 @@ void Lua::init()
         addFunction("drawBox",                &Utils::drawBox).
         addFunction("drawProgressBar",        &Utils::drawProgressBar).
         addFunction("draw2dLine",            &Utils::draw2dLine).
+        addFunction("drawLine", &Utils::drawLine).
+        addFunction("drawTriangle", &Utils::drawTriangle).
+        addFunction("drawSector", &Utils::drawSector).
+        addFunction("drawCircle", &Utils::drawCircle).
+        addFunction("drawRectTextured", &Utils::drawRectTextured).
+        addFunction("drawLineTextured", &Utils::drawLineTextured).
 
         // Custom HUD getter functions
         beginNamespace("viewPort").

--- a/TAMods/Utils.h
+++ b/TAMods/Utils.h
@@ -52,6 +52,8 @@ namespace Utils
 
     // Canvas drawing
     void drawTextMain(const std::string &str, const FColor &col, float x, float y, const unsigned char &align, const int &shadowSize, const float &scale, const unsigned &size, const unsigned char &fontNum);
+    void drawTextMain(const std::string& str, const FColor& col, float x, float y, const unsigned char& align, const int& shadowSize, const float& scale, const unsigned& size, const char* fontName);
+    void drawCustomText(const std::string& str, const FColor& col, float x, float y, const unsigned char& align, const int& shadowSize, const float& scale, const char* fontName);
     void drawText(const std::string &str, const FColor &col, float x, float y, const unsigned char &align, const float &scale);
     void drawSmallText(const std::string &str, const FColor &col, float x, float y, const unsigned char &align, const int &shadowSize, const float &scale);
     void drawUTText(const std::string &str, const FColor &col, float x, float y, const unsigned char &align, const int &shadowSize, const unsigned &size);
@@ -65,6 +67,12 @@ namespace Utils
     void drawBox(const float &x1, const float &y1, const float &x2, const float &y2, const FColor &col);
     void drawProgressBar(float x1, float y1, float x2, float y2, const FColor &col, const unsigned char &dir, const float &alpha);
     void draw2dLine(const float &x1, const float &y1, const float &x2, const float &y2, const FColor &col);
+    void drawLine(const float& x1, const float& y1, const float& x2, const float& y2, const float& perc, const float& width, const FColor& col);
+    void drawTriangle(float x1, float y1, float x2, float y2, float x3, float y3, const char* texName);
+    void drawSector(float x, float y, float radius, float startAngle, float endAngle, int segements, const char* texName);
+    void drawCircle(float centerX, float centerY, float radius, const char* texName);
+    void drawRectTextured(const float& x1, const float& y1, const float& x2, const float& y2, const FColor& col, const char* texName);
+    void drawLineTextured(const float& x1, const float& y1, const float& x2, const float& y2, const FVector4& uvMapping, const float& width, const FColor& col, const char* texName);
 
     ATrDevice* getDeviceByEquipPointHelper(unsigned const char &n);
     ATrDevice* getDeviceByWeaponIDHelper(int weapon_id);


### PR DESCRIPTION
Added functions:
- drawCustomText
- drawLine 
- drawTriangle
- drawSector
- drawCircle
- drawRectTextured
- drawLineTextured

Example usage for functions:

drawCustomText( text, color, xpos, ypos, align, shadowSize, scale, *texName)
drawLine( x1, y1, x2, y2, percentage (of length), width, color);
drawTriangle( x1, y1, x2, y2, x3, y3, texName);
drawSector( x,  y, radius, startAngle, endAngle, segments, texName);
drawCircle( centerX, centerY, radius, texName);
drawRectTextured( x1, y1, x2, y2, color, texName);
drawLineTextured( x1, y1, x2, y2, *uvMapping,  width,  color, texName);

texName is in the format - "MultiFont Hud_Items.MF_Medium" list can be found - https://docs.google.com/document/d/18PoTVLbkjZQYwuyV5rabqVkRrixVssFo6cB76dDnovw/edit#heading=h.ulysmxgqlvor

uvMapping is a Vecor 4, that can be written as "Vector4( x1, y1, x2, y2)" in Lua